### PR TITLE
Add default ansible.cfg

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,16 @@ You should provide the following arguments:
 
 Finally, you can deploy the playbook as follows (using the example hosts file):
 
-`ansible-playbook ./c4b-environment.yml -i ./hosts.yml`
+```bash
+ansible-playbook ./c4b-environment.yml
+```
 
 You will be prompted for any values you have not provided in `--extra-vars` or another fashion. An example of passing a variable on the command-line is as follows:
 
-`ansible-playbook ./c4b-environment --extra-vars "license_path=/path/to/chocolatey.license.xml certificate_path=/path/to/certificate.pfx"`
+```bash
+ansible-playbook ./c4b-environment \
+    --extra-vars "license_path=/path/to/chocolatey.license.xml certificate_path=/path/to/certificate.pfx"
+```
 
 You can also define variables in AWX, or within a file. For further details, see [Defining variables at runtime](https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_variables.html#passing-variables-on-the-command-line).
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ ansible-playbook ./c4b-environment.yml
 You will be prompted for any values you have not provided in `--extra-vars` or another fashion. An example of passing a variable on the command-line is as follows:
 
 ```bash
-ansible-playbook ./c4b-environment \
+ansible-playbook ./c4b-environment.yml \
     --extra-vars "license_path=/path/to/chocolatey.license.xml certificate_path=/path/to/certificate.pfx"
 ```
 

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,3 @@
+[defaults]
+callback_result_format = yaml
+inventory = hosts.yml


### PR DESCRIPTION
## Description Of Changes
Adds an ansible.cfg that automatically sets the inventory file as well as changes the output format from json to yaml. Also updates the README to format the ansible invocation commands to hopefully make it easier for people to view online.

## Motivation and Context
The default inventory means people can omit it when calling `ansible-playbook`. The yaml callback output is IMO a lot easier to read and understand https://www.jeffgeerling.com/blog/2018/use-ansibles-yaml-callback-plugin-better-cli-experience. If you prefer not use this then I'm happy to take it back out

## Testing

### Operating Systems Testing
N/A

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [x] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue
N/A