### PR TITLE
Add support for ECDSA Certificates

### DIFF
--- a/setup-ccm.yml
+++ b/setup-ccm.yml
@@ -121,6 +121,16 @@
     choco_args:
       - "--package-parameters-sensitive='/ConnectionString:{{ database_connection_string }}'"
 
+# FUTURE look into using ansible.windows.win_acl when 2.2.0 is more readily available
+# It simplifies private key ACL management so you don't have to do all this mess.
+# - name: Grant read access to the private key for the Chocolatey Web AppPool
+#   ansible.windows.win_acl:
+#     path: Cert:\LocalMachine\TrustedPeople\{{ certificate_thumbprint }}
+#     user: IIS AppPool\ChocolateyCentralManagement
+#     type: allow
+#     state: present
+#     rights: Read
+
 - name: Set Chocolatey Central Management Web Certificate
   ansible.windows.win_powershell:
     parameters:
@@ -140,14 +150,52 @@
         }
 
         # Adjust permissions on the certificate
-        $KeyName = (Get-Item Cert:\LocalMachine\TrustedPeople\$CertificateThumbprint).PrivateKey.CspKeyContainerInfo.UniqueKeyContainerName
-        $FullPath = Join-Path $env:ProgramData "\Microsoft\Crypto\RSA\MachineKeys\$($KeyName)"
-        if (Test-Path $FullPath) {
-          $Acl = Get-Acl $FullPath
-          $AccessRule = New-Object System.Security.AccessControl.FileSystemAccessRule("IIS AppPool\ChocolateyCentralManagement", "Read", "Allow")
-          $Acl.SetAccessRule($AccessRule)
-          Set-Acl $FullPath $Acl
-        } else {
+
+        # The PrivateKey property only works for RSA keys. To support ECDSA
+        # keys (and any future algos) we need to use the extension methods.
+        $cert = Get-Item Cert:\LocalMachine\TrustedPeople\$CertificateThumbprint
+
+        $key = $null
+        foreach ($keyMethod in @(
+          [System.Security.Cryptography.X509Certificates.RSACertificateExtensions]::GetRSAPrivateKey
+          [System.Security.Cryptography.X509Certificates.ECDsaCertificateExtensions]::GetECDsaPrivateKey
+        )) {
+            $key = $keyMethod.Invoke($cert)
+            if ($key) {
+              break
+            }
+        }
+        if (-not $key) {
+          $keyAlgoOid = $cert.PublicKey.Oid
+          $algoName = if ($keyAlgoOid.FriendlyName) { $keyAlgoOid.FriendlyName } else { $keyAlgoOid.Value }
+          Write-Error "Unknown certificate algorithm '$algoName', cannot set permissions." -ErrorAction Stop
+        }
+
+        # The location of the private key differs based on the provider used
+        # and how the key was imported.
+        $keyFound = $false
+        foreach ($keyLocation in @(
+          # CNG - Shared Private
+          "Microsoft\Crypto\Keys"
+          # CryptoAPI - Legacy Provider
+          "Microsoft\Crypto\RSA\MachineKeys"
+        )) {
+          $KeyPath = [System.IO.Path]::Combine($env:ProgramData, $keyLocation, $key.Key.UniqueName)
+          if (Test-Path -LiteralPath $KeyPath) {
+              $Acl = Get-Acl -LiteralPath $KeyPath
+              $AccessRule = [System.Security.AccessControl.FileSystemAccessRule]::new(
+                "IIS AppPool\ChocolateyCentralManagement",
+                "Read",
+                "Allow")
+              $Acl.SetAccessRule($AccessRule)
+              Set-Acl $FullPath $Acl
+
+              $keyFound = $true
+              break
+          }
+        }
+
+        if (-not $keyFound) {
           Write-Error "Private Key may not be available for export. Ensure import was successful." -ErrorAction Stop
         }
 


### PR DESCRIPTION
## Description Of Changes
Adds support for using an ECDSA based certificate which is becoming more common as people move away from RSA. As part of this change it is now able to get the unique key container name for both RSA and ECDSA types but also support editing permissions on keys using the older Legacy CryptoAPI providers and the newer CNG providers.

## Motivation and Context
See above

## Testing
Ran playbook on a new environment with an ECDSA key. You can use the following to generate an ECDSA key using OpenSSL

```bash
openssl ecparam \
    -name secp384r1 \
    -genkey \
    -noout \
    -out cert.key

openssl req \
    -new \
    -x509 \
    -out cert.pem \
    -key cert.key \
    -days 365 \
    -subj "/CN=server.chocolatey.test" \
    -addext "subjectAltName = DNS:server.chocolatey.test"

openssl pkcs12 \
    -export \
    -certpbe PBE-SHA1-3DES \
    -keypbe PBE-SHA1-3DES \
    -macalg SHA1 \
    -out cert.pfx \
    -inkey cert.key \
    -in cert.pem
```

### Operating Systems Testing
Server 2022 but should be supported all the way back to Server 2008. The dotnet APIs should not matter as the playbook install .NET 4.8 which is essentially the latest available.

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue
